### PR TITLE
sbt 1 needed in this repo

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+updates.pin = [
+  # we have too many build plugins that need sbt 1.x
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
+]
+
+updatePullRequests = "always"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.2
+sbt.version=1.12.14

--- a/project/paradox.sbt
+++ b/project/paradox.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.7")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.7")


### PR DESCRIPTION
sbt 2 does not work because we need plugins that don't work in sbt 2
java 17 changes in CI have busted the build too - so I had to fix the paradox.sbt file